### PR TITLE
Adicionado função para definir o local de armazenamento dos documento fiscais

### DIFF
--- a/nfe/sped/nfe/processing/processor.py
+++ b/nfe/sped/nfe/processing/processor.py
@@ -24,6 +24,8 @@ from pysped.nfe.danfe import DAEDE
 
 from .certificado import Certificado
 
+from openerp.addons.nfe.tools.misc import mount_path_nfe
+
 
 class DANFE(DanfePySped):
     def __init__(self):
@@ -45,7 +47,7 @@ class ProcessadorNFe(ProcessadorNFePySped):
         self.estado = company.partner_id.l10n_br_city_id.state_id.code
         self.versao = company.nfe_version
         self.certificado = Certificado(company)
-        self.caminho = company.nfe_root_folder
+        self.caminho = mount_path_nfe(company, 'nfe')
         self.salvar_arquivos = False
         self.contingencia_SCAN = False
         self.contingencia = False

--- a/nfe/sped/nfe/processing/xml.py
+++ b/nfe/sped/nfe/processing/xml.py
@@ -30,6 +30,8 @@ from .certificado import Certificado
 from .processor import ProcessadorNFe
 from pysped.nfe.danfe import DANFE
 
+from openerp.addons.nfe.tools.misc import mount_path_nfe
+
 
 def __processo(company):
 
@@ -39,7 +41,7 @@ def __processo(company):
     p.certificado = Certificado(company)
     p.salvar_arquivos = True
     p.contingencia_SCAN = False
-    p.caminho = company.nfe_root_folder
+    p.caminho = mount_path_nfe(company)
     return p
 
 
@@ -168,7 +170,7 @@ def print_danfe(inv):
 def add_backgound_to_logo_image(company):
     logo = company.logo
     logo_image = Image.open(StringIO(logo.decode('base64')))
-    image_path = os.path.join(company.nfe_root_folder, 'company_logo.png')
+    image_path = os.path.join(mount_path_nfe(company), 'company_logo.png')
 
     bg = Image.new("RGB", logo_image.size, (255, 255, 255))
     bg.paste(logo_image, logo_image)

--- a/nfe/sped/nfe/validator/config_check.py
+++ b/nfe/sped/nfe/validator/config_check.py
@@ -59,7 +59,5 @@ def validate_nfe_configuration(company):
         error += u'Empresa - Arquivo NF-e A1\n'
     if not company.nfe_a1_password:
         error += u'Empresa - Senha NF-e A1\n'
-    if not company.nfe_root_folder:
-        error += u'Empresa - Pasta de exportação\n'
     if error != u'As seguintes configurações estão faltando:\n':
         raise orm.except_orm(_(u'Validação !'), _(error))

--- a/nfe/tools/__init__.py
+++ b/nfe/tools/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+# Copyright (C) 2016  Renato Lima - Akretion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+
+from . import misc

--- a/nfe/tools/misc.py
+++ b/nfe/tools/misc.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+# Copyright (C) 2016  Renato Lima - Akretion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+
+import os
+
+from openerp.tools import config
+from openerp.tools.translate import _
+from openerp.exceptions import RedirectWarning
+from openerp.addons.l10n_br_base.tools.misc import punctuation_rm
+
+
+def mount_path_nfe(company, document='nfe'):
+    db_name = company._cr.dbname
+    cnpj = punctuation_rm(company.cnpj_cpf)
+    data_dir = config['data_dir']
+
+    nfe_path = '/'.join([data_dir, document, db_name, cnpj])
+    if not os.path.exists(nfe_path):
+        try:
+            os.makedirs(nfe_path)
+        except OSError:
+            raise RedirectWarning(
+                _(u'Erro!'),
+                _(u"""Verifique as permissões de escrita
+                    e o caminho da pasta"""))
+    return nfe_path

--- a/nfe/tools/misc.py
+++ b/nfe/tools/misc.py
@@ -28,9 +28,9 @@ from openerp.addons.l10n_br_base.tools.misc import punctuation_rm
 def mount_path_nfe(company, document='nfe'):
     db_name = company._cr.dbname
     cnpj = punctuation_rm(company.cnpj_cpf)
-    data_dir = config['data_dir']
 
-    nfe_path = '/'.join([data_dir, document, db_name, cnpj])
+    filestore = config.filestore(db_name)
+    nfe_path = '/'.join([filestore, 'PySPED', document, cnpj])
     if not os.path.exists(nfe_path):
         try:
             os.makedirs(nfe_path)


### PR DESCRIPTION
Olá pessoal,

Este PR tem o objetivo de eliminarmos o campo nfe_root_folder onde é definido a pasta de armazenamento da NFe, e usar o parâmetro do arquivo de configuração data_dir, que é utilizado também para armazenar os arquivos em anexo do módulo document, desta forma facilita a organização e a manutenção já que o conteúdo (anexos e arquivos do pysped) ficaria em uma unica pasta o que facilitaria no caso de backups, eu implementei a seguinte organização das pastas:

FILESTORE
                    nfe
                          db
                              3006689800006
                   nfce
                         db
                              3006689800006

Ficando dentro do filestore: DOCUMENTO_FISCAL/BANCO_DE_DADOS/CNPJ

Eu criei também uma função onde é parametrizável também o tipo de documento fiscal (nfe, nfce, cte e etc) para ser usado futuramente.

O que acham @danimaribeiro @mileo 
