### PR TITLE
Adicionado campo especifico para definir a logo para a NFe

### DIFF
--- a/nfe/models/res_company.py
+++ b/nfe/models/res_company.py
@@ -24,3 +24,4 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     nfe_email = fields.Text('Observação em Email NFe')
+    nfe_logo = fields.Binary('NFe Logo')

--- a/nfe/sped/nfe/processing/xml.py
+++ b/nfe/sped/nfe/processing/xml.py
@@ -166,7 +166,7 @@ def print_danfe(inv):
 
 
 def add_backgound_to_logo_image(company):
-    logo = company.logo
+    logo = company.nfe_logo or company.logo
     logo_image = Image.open(StringIO(logo.decode('base64')))
     image_path = os.path.join(company.nfe_root_folder, 'company_logo.png')
 

--- a/nfe/views/res_company_view.xml
+++ b/nfe/views/res_company_view.xml
@@ -6,6 +6,14 @@
 			<field name="model">res.company</field>
 			<field name="inherit_id" ref="l10n_br_account_product.view_l10n_br_account_company_form"/>
 			<field name="arch" type="xml">
+                <page string="NFe" position="inside">
+                    <group string="Logo para NFe">
+                        <div>
+                        <label class="oe_edit_only" string="Esta imagem será utilizada na impressão dos DANFEs"/>
+                        <field name="nfe_logo" widget="image" class="oe_left"/>
+                        </div>
+                    </group>
+                </page>
 				<xpath expr="//field[@name='export_folder']" position="after">
 					<field name="nfe_email"/>
 				</xpath>


### PR DESCRIPTION
Este PR adiciona um campo nfe_logo no cadastro de empresa para permitir a possibilidade de definir uma logo diferente, porque nem sempre a logo que deve ser impressa no DANFE é a logo da empresa, em casos como multi company (matriz e filial) ou holdings. Se este campo estiver vazio será impresso a logo da empresa no DANFE

@danimaribeiro @mileo 
