### PR TITLE
Lida com resultado 573 no evento ciencia_operacao

### DIFF
--- a/nfe_mde/nfe_mde.py
+++ b/nfe_mde/nfe_mde.py
@@ -94,6 +94,9 @@ class Nfe_Mde(models.Model):
 
         if nfe_result['code'] == '135':
             self.state = 'ciente'
+        elif nfe_result['code'] == '573':
+            self.state = 'ciente'
+            event['response'] = 'Ciência da operação já previamente realizada'
         else:
             event['response'] = 'Ciência da operação sem êxito'
 


### PR DESCRIPTION
Quando um documento já recebeu evento de ciência da operação, o SEFAZ
responde à operação com o resultado 573 (duplicidade de evento).

Neste caso, atualizamos o status do documento para refletir a situação
no SEFAZ.
