### PR TITLE
Parâmetro para definir a geração da DANFE

### DIFF
--- a/nfe/models/res_company.py
+++ b/nfe/models/res_company.py
@@ -26,3 +26,4 @@ class ResCompany(models.Model):
     nfe_email = fields.Text('Observação em Email NFe')
     nfe_logo = fields.Binary('NFe Logo')
     nfe_logo_vertical = fields.Boolean('Logo na Vertical')
+    danfe_automatic_generate = fields.Boolean('Gera DANFE Automaticamente')

--- a/nfe/sped/nfe/processing/processor.py
+++ b/nfe/sped/nfe/processing/processor.py
@@ -31,14 +31,6 @@ class DANFE(DanfePySped):
     def __init__(self):
         super(DANFE, self).__init__()
 
-    def gerar_danfe(self):
-        """
-        Remove a geração automática do DANFE para deixar o processo + leve
-        :return:
-        """
-        self.conteudo_pdf = ''
-        return
-
 
 class ProcessadorNFe(ProcessadorNFePySped):
     def __init__(self, company):

--- a/nfe/sped/nfe/processing/xml.py
+++ b/nfe/sped/nfe/processing/xml.py
@@ -90,6 +90,7 @@ def send(company, nfe):
     p.versao = str(nfe[0].infNFe.versao.valor)
     p.danfe.logo = add_backgound_to_logo_image(company)
     p.danfe.leiaute_logo_vertical = company.nfe_logo_vertical
+    p.danfe.salvar_arquivo = company.danfe_automatic_generate
     p.danfe.nome_sistema = company.nfe_email or \
         u"""Odoo/OpenERP - Sistema de Gestao Empresarial de Codigo Aberto
         - 100%% WEB - www.openerpbrasil.org"""

--- a/nfe/views/res_company_view.xml
+++ b/nfe/views/res_company_view.xml
@@ -20,6 +20,7 @@
                 </page>
 				<xpath expr="//field[@name='export_folder']" position="after">
 					<field name="nfe_email"/>
+					<field name="danfe_automatic_generate"/>
 				</xpath>
 			</field>
 		</record>


### PR DESCRIPTION
Incluído parâmetro se o programa deve ou não gerar a DANFE ao gerar uma NFe, antes existia um método que sobre escrevia o método original do PySPED para evitar que o arquivo fosse gerado deixando a geração da NFe mais "leve", porém isso deve ser configurável pelos usuários. Esse PR depende deste https://github.com/odoo-brazil/PySPED/pull/23 
