### PR TITLE
[FIX] Invoice print button error: TypeError: 'int' object is not iterable

### DIFF
--- a/nfe/models/account_invoice.py
+++ b/nfe/models/account_invoice.py
@@ -316,7 +316,7 @@ class AccountInvoice(models.Model):
             datas = {
                 'ids': inv.ids,
                 'model': 'account.invoice',
-                'form': self.read(inv.id)
+                'form': self.read()
             }
 
             return {


### PR DESCRIPTION
Erro exibido quando, após transmitirmos uma NFe com sucesso e pressionamos o botão  "Imprimir Fatura" na tela de Invoice. 
